### PR TITLE
Add `--locked` and update docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ sudo su - routinator
 
 13.	Install the routinator software and add it to the $PATH for user routinator
 ```
-cargo install routinator
+cargo install --locked routinator
 vi /home/routinator/.bash_profile
 # Edit the PATH line to include "/home/routinator/.cargo/bin"
 PATH=$PATH:$HOME/.local/bin:$HOME/bin:/home/routinator/.cargo/bin
@@ -134,5 +134,5 @@ sudo firewall-cmd --reload
 19. Navigate to "https://(IP address of rpki-validator)/metrics" to see if it's working. You should authenticate with the user/pass that you provided in step 10 of setting up the RPKI Validation Server.
 
 
-## More info on Routinator can be found at https://rpki.readthedocs.io/en/latest/routinator/
+## More info on Routinator can be found at https://routinator.docs.nlnetlabs.nl/
 


### PR DESCRIPTION
Sometimes compiling will fail because the latest version of dependencies do not work, e.g. [here](https://github.com/NLnetLabs/routinator/issues/598). This is why the installation instructions for compiling Routinator now use the `--locked` option everywhere, to force Cargo to use the packaged Cargo.lock file. 

Also, the canonical link for the Routinator documentation changed.